### PR TITLE
feat: added api endpoint for disconnecting gcal

### DIFF
--- a/app/api/google.py
+++ b/app/api/google.py
@@ -10,7 +10,8 @@ from app.services.google_service import (
     fetch_events_for_calendars,
     add_event,
     delete_event,
-    credentials_to_dict
+    credentials_to_dict,
+    revoke_user_google_credentials
 )
 from app.models.google_event import save_google_event, get_google_event_by_local_id, delete_google_event_by_local_id
 from app.models.user import get_user_by_clerk_id
@@ -31,6 +32,15 @@ def authorize():
     session["state"] = state
     session["post_auth_redirect"] = redirect_url
     return redirect(authorization_url)
+
+@google_bp.route("/unauthorize", methods=["DELETE", "OPTIONS"])
+def unauthorize_google():
+    # your logic to revoke credentials, e.g.:
+    try:
+        revoke_user_google_credentials()
+        return jsonify({"message": "Google account unauthorized"}), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
 
 @google_bp.route("/oauth/callback")
 def oauth2callback():

--- a/app/services/google_service.py
+++ b/app/services/google_service.py
@@ -4,6 +4,7 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from flask import session
 from datetime import datetime, timedelta, timezone
+import requests
 
 
 SCOPES = [
@@ -133,5 +134,22 @@ def synced_event_to_dict(event):
         "end": event.end,
         "synced_at": event.synced_at.isoformat() if event.synced_at else None
     }
+
+def revoke_user_google_credentials():
+    creds = session.get("credentials")
+    if not creds:
+        return
+    token = creds.get("token")
+    if token:
+        # Revoke the token via Google's API
+        requests.post(
+            'https://oauth2.googleapis.com/revoke',
+            params={'token': token},
+            headers={'content-type': 'application/x-www-form-urlencoded'}
+        )
+
+    # Clear credentials from session
+    session.pop("credentials", None)
+
 
 


### PR DESCRIPTION
# Name of PR:

## 1. Issue

**Link to the associated GitHub/Notion issue:**
https://www.notion.so/wiki-scottylabs/Onboarding-Tutorial-23796192554c8002a154c87e016ab0e0?v=27496192554c800ab503000c54ac6fbc&source=copy_link


## 2. Changes

**What changes did you make to resolve the issue?**
Added api/google/unauthorize endpoint to disconnect a user's google calendar

**Does your change introduce new dependencies to this project? If so, list here.**
No

## 3. Validation

**How did you trigger the change to show that it is working?**
Tested that a user can remove the connected google calendars without causing an error. Note that this PR is complementary to Jalen's [Jl signup google flow](https://github.com/ScottyLabs/cmucal/pull/40#issue-3484157585) PR in the frontend repo.



