### PR TITLE
Fix: Tell flask to trust railway's proxy headers

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ import os
 from dotenv import load_dotenv
 from pathlib import Path
 from flask import Flask
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 # Load environment variables from .env file BEFORE other imports
 def detect_env() -> str:
@@ -34,6 +35,7 @@ def create_app():
         app.config.from_object(TestingConfig)
     else:
         app.config.from_object(DevelopmentConfig)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1) # tell Flask to trust Railway’s proxy headers
 
     if not os.getenv("ALEMBIC_RUNNING"): # skip during Alembic
         from flask_cors import CORS


### PR DESCRIPTION
# Fix: Tell flask to trust railway's proxy headers

## 1. Issue
- Browser sends `https://api.cal.scottylabs.org/...` but proxy forwards request to Flask as `http://<internal-ip>:<port>/api/google/oauth/callback`
- Flask sees `http://` and raises `InsecureTransportError`


## 2. Changes
- Tell Flask to trust Railway’s proxy headers

## 3. Validation
- Verified that the frontend app still runs, specifically the connect to google button still works


