### PR TITLE
Fix: added error handling for parsing ical link

### DIFF
--- a/app/errors/ical.py
+++ b/app/errors/ical.py
@@ -1,0 +1,6 @@
+# app/errors/ical.py
+class ICalFetchError(Exception):
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)


### PR DESCRIPTION
# Name of PR:

## 1. Issue

**Link to the associated GitHub/Notion issue:**
- Backend features for https://github.com/ScottyLabs/cmucal/pull/50


## 2. Changes

**What changes did you make to resolve the issue?**
- Added custom error messages in `ical.py`
- Let the error from `_fetch_ics_text()` in `ical.py` bubble up to `read_gcal_link()` in `events.py` 


**Does your change introduce new dependencies to this project? If so, list here.**
- No



