### PR TITLE
Automate semester selection for SOC scraper

### DIFF
--- a/scraper/README.md
+++ b/scraper/README.md
@@ -20,6 +20,18 @@
    - **Explicit label(s):** Pass one or more labels, e.g. `python -m scraper.scripts.export_soc Spring_26` or `Spring_26 Fall_25`. Formats: `Spring_xx`, `Fall_xx`, `Summer1_xx`, `Summer2_xx` (same as `get_current_semester` in `semester.py`).
    - **Season flags (only when you are *not* passing labels):** `--spring` scrapes only the `Spring_*` entry from the automatic pair; `--fall` only `Fall_*`; neither flag (or both flags together) uses the full automatic pair.
 
+     Examples:
+
+     | Command | OK? |
+     |--------|-----|
+     | `python -m scraper.scripts.export_soc` | Yes — full automatic pair (same as cron). |
+     | `python -m scraper.scripts.export_soc --spring` | Yes — only Spring from that pair. |
+     | `python -m scraper.scripts.export_soc --fall` | Yes — only Fall from that pair. |
+     | `python -m scraper.scripts.export_soc --spring --fall` | Yes — full pair again (explicit “both”). |
+     | `python -m scraper.scripts.export_soc Spring_26` | Yes — exactly that semester (ignores season flags). |
+     | `python -m scraper.scripts.export_soc Spring_26 Fall_25` | Yes — only those labels. |
+     | `python -m scraper.scripts.export_soc Spring_26 --spring` | No — parser error; use either explicit labels **or** `--spring`/`--fall`, not both. |
+
    Use `python -m scraper.scripts.export_soc -h` for the full CLI help.
 
 3. The script creates org and category for each SOC event if those don’t exist, then adds events, recurrence rules, and calls an endpoint to generate event occurrences. Generating all events can take around an hour; keep the terminal open during that time.

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -8,12 +8,21 @@
 `python exporters/schedule_of_classes_export_to_excel.py` -->
 ## Development Environment
 1. Activate the virtual environment at the root directory
-2. If running the schedule of classes scraper, make sure to change the semester_label in `scraper = ScheduleOfClassesScraper(db, semester_label="Spring_26")`. 
-    - Acceptable formats include `Spring_xx`, `Fall_xx`, `Summer1_xx`, `Summer2_xx`.
-    - Feel free to change the start and end dates of each semester in `scraper/helpers/semester.py` if needed.
-3. Run `python -m scraper.scripts.export_soc` to scrape data and add events to the DB.
-    - the script first creates org and category for each SOC event if those don't exist, then add events, recurrence_rules, and calls an endpoint to generate event occurrences.
-    - generating all events could take around an hour, please keep the terminal open during that time.
+2. Run the Schedule of Classes export from the **backend root** (`cmucal-backend`), not inside `scraper/`:
+
+   ```bash
+   python -m scraper.scripts.export_soc
+   ```
+
+   **Semester selection (no code edits needed):**
+
+   - **Default (cron-friendly):** With no arguments, the script picks the current and next major term (Spring and Fall layouts) from today’s date. Logic lives in `scraper/helpers/semester.py` (`infer_soc_semester_labels`). Adjust start/end dates there if CMU’s calendar drifts.
+   - **Explicit label(s):** Pass one or more labels, e.g. `python -m scraper.scripts.export_soc Spring_26` or `Spring_26 Fall_25`. Formats: `Spring_xx`, `Fall_xx`, `Summer1_xx`, `Summer2_xx` (same as `get_current_semester` in `semester.py`).
+   - **Season flags (only when you are *not* passing labels):** `--spring` scrapes only the `Spring_*` entry from the automatic pair; `--fall` only `Fall_*`; neither flag (or both flags together) uses the full automatic pair.
+
+   Use `python -m scraper.scripts.export_soc -h` for the full CLI help.
+
+3. The script creates org and category for each SOC event if those don’t exist, then adds events, recurrence rules, and calls an endpoint to generate event occurrences. Generating all events can take around an hour; keep the terminal open during that time.
 
 * If need to delete, run this:
 ```
@@ -23,7 +32,7 @@ curl -X DELETE http://localhost:5001/api/events/batch_delete_events_by_params \
 ```
 
 ## Production Environment
-- created a cron job on Railway that calls `python -m scraper.scripts.export_soc`
+- Cron on Railway runs `python -m scraper.scripts.export_soc` with **no arguments**, so each run uses the automatic Spring/Fall pair for the current date. Override locally or in a one-off job with explicit labels or `--spring` / `--fall` if needed.
 
 # Old README
 

--- a/scraper/helpers/semester.py
+++ b/scraper/helpers/semester.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 
 SEMESTER_CONFIG = {
@@ -59,3 +59,35 @@ def get_current_semester(
         start,
         end,
     )
+
+
+def infer_soc_semester_labels(
+    today: Optional[datetime.date] = None,
+) -> List[str]:
+    """
+    SOC publishes separate Spring and Fall layouts. Return labels for the
+    current calendar window and the next major term so cron runs stay fresh
+    without manual edits.
+
+    - Jan–May: Spring (this year) then Fall (this year).
+    - Jun–Jul: Spring (this year, just ended / winding down) then Fall (this year).
+    - Aug–Dec: Fall (this year) then Spring (next year), e.g. December → Fall + Spring.
+
+    Labels match get_current_semester format, e.g. Spring_26, Fall_25.
+    """
+    d = today or datetime.date.today()
+    y = d.year
+    yy = f"{y % 100:02d}"
+
+    if d.month >= 8:
+        fall = f"Fall_{yy}"
+        spring_next = f"Spring_{(y + 1) % 100:02d}"
+        return [fall, spring_next]
+    if 1 <= d.month <= 5:
+        spring = f"Spring_{yy}"
+        fall = f"Fall_{yy}"
+        return [spring, fall]
+    # June–July: upcoming Fall and the Spring that just ended (same calendar year).
+    spring = f"Spring_{yy}"
+    fall = f"Fall_{yy}"
+    return [spring, fall]

--- a/scraper/scripts/export_soc.py
+++ b/scraper/scripts/export_soc.py
@@ -6,6 +6,7 @@ ENV = load_env()
 API_BASE_URL = get_api_base_url()
 
 from scraper.monitors.academic import ScheduleOfClassesScraper
+from scraper.helpers.semester import infer_soc_semester_labels
 from scraper.persistence.supabase_categories import ensure_lecture_category
 from scraper.persistence.supabase_agent_run import insert_agent_run
 from scraper.transforms.soc_org_course import build_orgs_and_courses
@@ -16,10 +17,27 @@ from scraper.transforms.soc_events import build_events_and_rrules
 from scraper.persistence.supabase_events import insert_events
 from scraper.persistence.supabase_recurrence import replace_recurrence_rules
 
+import argparse
 import logging
 import traceback
+from typing import Optional, Sequence
 
 logger = logging.getLogger(__name__)
+
+
+def _apply_season_flags(
+    labels: Sequence[str],
+    *,
+    spring: bool,
+    fall: bool,
+) -> list[str]:
+    """Narrow inferred labels: only --spring, only --fall, or both (neither or both flags)."""
+    if spring == fall:
+        return list(labels)
+    if spring:
+        return [L for L in labels if L.startswith("Spring_")]
+    return [L for L in labels if L.startswith("Fall_")]
+
 
 def export_soc_safe():
     try:
@@ -30,14 +48,25 @@ def export_soc_safe():
         logger.error("❌ export_soc failed")
         logger.error(traceback.format_exc())
 
-def export_soc():
+def export_soc(semester_labels: Optional[Sequence[str]] = None):
     """ Scrape the Schedule of Classes and export to Supabase 
         - Note that nothing rolls back automatically.
         - The system is designed to heal itself on rerun, and does not rely on rollback
+
+        semester_labels: if provided, only these labels (e.g. Spring_26) are scraped;
+        if None, uses infer_soc_semester_labels() for cron-friendly defaults.
     """
     db = get_supabase()
-    scraper = ScheduleOfClassesScraper(db, semester_label="Spring_26")
-    resources = scraper.scrape_data_only()
+    labels = (
+        list(semester_labels)
+        if semester_labels
+        else infer_soc_semester_labels()
+    )
+    logger.info("SOC semesters for this run: %s", ", ".join(labels))
+    resources = []
+    for label in labels:
+        scraper = ScheduleOfClassesScraper(db, semester_label=label)
+        resources.extend(scraper.scrape_data_only())
 
     # agent run
     agent_run_id = insert_agent_run(db, agent_version="soc_v1")
@@ -77,5 +106,51 @@ def export_soc():
         
     print(f"✅ Called regeneration for {len(affected_event_ids)} events. See logs for details.")
 
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Export CMU Schedule of Classes to Supabase.",
+    )
+    parser.add_argument(
+        "semester",
+        nargs="*",
+        metavar="LABEL",
+        help=(
+            "Semester label(s) such as Spring_26 or Fall_25. "
+            "If omitted, uses automatic current and next terms (see --spring / --fall)."
+        ),
+    )
+    parser.add_argument(
+        "--spring",
+        action="store_true",
+        help=(
+            "With no LABEL arguments: only scrape Spring_* from the automatic pair. "
+            "Combine with --fall to scrape the full automatic pair."
+        ),
+    )
+    parser.add_argument(
+        "--fall",
+        action="store_true",
+        help=(
+            "With no LABEL arguments: only scrape Fall_* from the automatic pair. "
+            "Combine with --spring to scrape the full automatic pair."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.semester:
+        if args.spring or args.fall:
+            parser.error(
+                "Do not use --spring/--fall together with explicit LABEL arguments."
+            )
+        export_soc(semester_labels=args.semester)
+        return
+
+    labels = infer_soc_semester_labels()
+    labels = _apply_season_flags(labels, spring=args.spring, fall=args.fall)
+    if not labels:
+        parser.error("No semesters left after --spring/--fall filter.")
+    export_soc(semester_labels=labels)
+
+
 if __name__ == "__main__":
-    export_soc()
+    main()


### PR DESCRIPTION
## Summary
- Infer Spring/Fall SOC labels from the current date (`infer_soc_semester_labels` in `scraper/helpers/semester.py`) so cron runs scrape the right terms without editing code.
- `export_soc` loops over inferred labels (or an explicit list) and merges resources before the existing Supabase pipeline.
- CLI: optional semester labels (`Spring_26`, …), `--spring` / `--fall` when using auto mode only, `-h` for help.
- README updated for the new workflow and examples (including invalid label + flag combinations).

## Next Step
- Generate event occurrences for fall/spring only, don't generate fall events in spring

## Test plan
- [ ] `python -m scraper.scripts.export_soc -h`
- [ ] `python -m scraper.scripts.export_soc` (no args) from backend root
- [ ] Optional: `Spring_26` only, `--spring` / `--fall` without labels